### PR TITLE
set perl minimum version to 5.008

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use ExtUtils::MakeMaker::CPANfile;
-use 5.006;
+use 5.008;
 
 WriteMakefile(
   NAME          => 'Path::Extended',
@@ -15,4 +15,5 @@ WriteMakefile(
     },
   },
   test => {RECURSIVE_TEST_FILES=>1},
+  MIN_PERL_VERSION => 5.008,
 );


### PR DESCRIPTION
the required minimum version was set to 5.006 which is not actually
correct since t/20_file/slurp.t depends on "use utf8" which requires
5.008
